### PR TITLE
Introduce Dev DB environment and noop

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+echo -n "Version? "
+read version
+export CGO_ENABLED=0
+set -x -u -o pipefail
+
+go build \
+    -ldflags="-X 'main.Version=${version}' -X 'main.buildTime=$(date -u)' -X 'main.buildCommit=$(git rev-parse HEAD)'" \
+    ./cmd/sandbox-list
+
+go build ./cmd/sandbox-metrics

--- a/cmd/sandbox-list/main.go
+++ b/cmd/sandbox-list/main.go
@@ -185,6 +185,9 @@ func main() {
 	if os.Getenv("AWS_REGION") == "" {
 		os.Setenv("AWS_REGION", "us-east-1")
 	}
+	if os.Getenv("dynamodb_table") == "" {
+		os.Setenv("dynamodb_table", "accounts")
+	}
 	sandboxdb.SetSession()
 
 	filters := []expression.ConditionBuilder{}

--- a/cmd/sandbox-list/main.go
+++ b/cmd/sandbox-list/main.go
@@ -20,6 +20,12 @@ var debugFlag bool
 var toCleanupFlag bool
 var noHeadersFlag bool
 var padding = 2
+var versionFlag bool
+
+// Build info
+var Version = "development"
+var buildTime = "undefined"
+var buildCommit = "HEAD"
 
 type accountPrint account.Account
 
@@ -109,10 +115,17 @@ func parseFlags() {
 	flag.BoolVar(&toCleanupFlag, "to-cleanup", false, "Print all marked for cleanup.")
 	flag.BoolVar(&noHeadersFlag, "no-headers", false, "Don't print headers.")
 	flag.BoolVar(&debugFlag, "debug", false, "Debug mode.\nEnvironment variable: DEBUG\n")
+	flag.BoolVar(&versionFlag, "version", false, "Print build version.")
 
 	flag.Parse()
 	if e := os.Getenv("DEBUG"); e != "" && e != "false" {
 		debugFlag = true
+	}
+	if versionFlag {
+		fmt.Println("Version:", Version)
+		fmt.Println("Build time:", buildTime)
+		fmt.Println("Build commit:", buildCommit)
+		os.Exit(0)
 	}
 }
 

--- a/conan/conan-dev.rc
+++ b/conan/conan-dev.rc
@@ -1,0 +1,6 @@
+export threads=2
+export aws_profile=pool-manager-dev
+export dynamodb_table=accounts-dev
+export dynamodb_region=us-east-1
+export aws_nuke_binary_path=/bin/true
+export noop=true

--- a/conan/conan-dev.service
+++ b/conan/conan-dev.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Conan the Destroyer of sandboxes (DEV)
 After=network-online.target
-Documentation=https://github.com/redhat-gpe/aws-sandbox/tree/main/conan
+Documentation=https://github.com/rhpds/aws-sandbox/tree/main/conan
 
 [Service]
 Environment=threads=2

--- a/conan/conan-dev.service
+++ b/conan/conan-dev.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Conan the Destroyer of sandboxes (DEV)
+After=network-online.target
+Documentation=https://github.com/redhat-gpe/aws-sandbox/tree/main/conan
+
+[Service]
+Environment=threads=2
+Environment=aws_profile=pool-manager-dev
+Environment=dynamodb_table=accounts-dev
+Environment=dynamodb_region=us-east-1
+Environment=aws_nuke_binary_path=/bin/true
+Environment=noop=true
+
+User=opentlc-mgr
+Group=opentlc-mgr
+Type=simple
+ExecStart=/bin/bash /home/opentlc-mgr/pool_management/aws-sandbox/conan/conan.sh
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
+[Install]
+WantedBy=multi-user.target

--- a/conan/conan.service
+++ b/conan/conan.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Conan the Destroyer of sandboxes
 After=network-online.target
-Documentation=https://github.com/redhat-gpe/aws-sandbox/tree/main/conan
+Documentation=https://github.com/rhpds/aws-sandbox/tree/main/conan
 
 [Service]
 Environment=threads=12

--- a/conan/conan.service
+++ b/conan/conan.service
@@ -4,6 +4,11 @@ After=network-online.target
 Documentation=https://github.com/redhat-gpe/aws-sandbox/tree/main/conan
 
 [Service]
+Environment=threads=12
+Environment=aws_profile=pool-manager
+Environment=dynamodb_table=accounts
+Environment=dynamodb_region=us-east-1
+
 User=opentlc-mgr
 Group=opentlc-mgr
 Type=simple

--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -6,13 +6,33 @@ set -u -o pipefail
 # conf
 ##############
 
-# Number of aws-nuke to run in parallel
-threads=12
+# Number of aws-nuke processes to run in parallel
+threads="${threads:-12}"
+
+# AWS profile
+aws_profile="${aws_profile:-pool-manager}"
+
+# DynamoDB
+dynamodb_table="${dynamodb_table:-accounts}"
+dynamodb_region="${dynamodb_table:-us-east-1}"
 
 # Pause between each iteration that gets the list of sandboxes to cleanup
-poll_interval=60
+poll_interval="${poll_interval:-60}"
+
+# aws-nuke path
+aws_nuke_binary_path=/usr/bin/aws-nuke
+
+# Noop: don't actually touch the sandboxes
+noop=${noop:-false}
 
 ##############
+export threads
+export aws_profile
+export dynamodb_table
+export dynamodb_region
+export poll_interval
+export aws_nuke_binary_path
+export noop
 
 ORIG="$(cd "$(dirname "$0")" || exit; pwd)"
 
@@ -33,8 +53,12 @@ cd ${ORIG}
 
 while true; do
 
-    sandbox-list --to-cleanup --no-headers \
-        | rush --immediate-output -j ${threads} './wipe_sandbox.sh {1}'
+    (
+        export AWS_PROFILE=${aws_profile}
+        export AWS_REGION=${dynamodb_region}
+        export dynamodb_table=${dynamodb_table}
+        sandbox-list --to-cleanup --no-headers
+    ) | rush --immediate-output -j ${threads} './wipe_sandbox.sh {1}'
 
     sleep ${poll_interval}
 done

--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -14,18 +14,19 @@ aws_profile="${aws_profile:-pool-manager}"
 
 # DynamoDB
 dynamodb_table="${dynamodb_table:-accounts}"
-dynamodb_region="${dynamodb_table:-us-east-1}"
+dynamodb_region="${dynamodb_region:-us-east-1}"
 
 # Pause between each iteration that gets the list of sandboxes to cleanup
 poll_interval="${poll_interval:-60}"
 
 # aws-nuke path
-aws_nuke_binary_path=/usr/bin/aws-nuke
+aws_nuke_binary_path="${aws_nuke_binary_path:-/usr/bin/aws-nuke}"
 
 # Noop: don't actually touch the sandboxes
 noop=${noop:-false}
 
 ##############
+
 export threads
 export aws_profile
 export dynamodb_table
@@ -36,6 +37,25 @@ export noop
 
 ORIG="$(cd "$(dirname "$0")" || exit; pwd)"
 
+VENV=~/pool_management/python_virtualenv
+export VENV
+
+prepare_workdir() {
+    mkdir -p ~/pool_management
+
+    if [ ! -d $VENV ]; then
+        set -e
+        echo "Create python virtualenv"
+        python3 -mvenv $VENV
+        . $VENV/bin/activate
+        pip install --upgrade pip
+        pip install -r ${ORIG}/../playbooks/requirements.txt
+        set +e
+    fi
+    . $VENV/bin/activate
+}
+
+
 pre_checks() {
     for c in sandbox-list \
              rush \
@@ -45,9 +65,18 @@ pre_checks() {
             exit 2
         fi
     done
+    sandbox-list --to-cleanup &> /dev/null
+    if [ $? != 0 ]; then
+        echo "command failed: sandbox-list --to-cleanup"
+        exit 2
+    fi
 }
 
+echo "AWS profile: ${aws_profile}"
+echo "DynamoDB table: ${dynamodb_table}"
+
 pre_checks
+prepare_workdir
 
 cd ${ORIG}
 

--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -61,14 +61,16 @@ pre_checks() {
              rush \
              kinit; do
         if ! command -v $c &>/dev/null; then
-            echo "'${c}' command not found"
-            exit 2
+            echo "'${c}' command not found" >&2
+            sync
+            exit 5
         fi
     done
     sandbox-list --to-cleanup &> /dev/null
     if [ $? != 0 ]; then
         echo "command failed: sandbox-list --to-cleanup"
-        exit 2
+        sync
+        exit 5
     fi
 }
 

--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -45,16 +45,16 @@ ORIG="$(cd "$(dirname "$0")" || exit; pwd)"
 prepare_workdir() {
     mkdir -p ~/pool_management
 
-    if [ ! -d $VENV ]; then
+    if [ ! -d "${VENV}" ]; then
         set -e
         echo "Create python virtualenv"
-        python3 -mvenv $VENV
-        . $VENV/bin/activate
+        python3 -mvenv "${VENV}"
+        . "${VENV}/bin/activate"
         pip install --upgrade pip
-        pip install -r ${ORIG}/../playbooks/requirements.txt
+        pip install -r "${ORIG}/../playbooks/requirements.txt"
         set +e
     fi
-    . $VENV/bin/activate
+    . "$VENV/bin/activate"
 }
 
 
@@ -68,8 +68,7 @@ pre_checks() {
             exit 5
         fi
     done
-    sandbox-list --to-cleanup &> /dev/null
-    if [ $? != 0 ]; then
+    if ! sandbox-list --to-cleanup &> /dev/null; then
         echo "command failed: sandbox-list --to-cleanup"
         sync
         exit 5
@@ -82,7 +81,7 @@ echo "DynamoDB table: ${dynamodb_table}"
 pre_checks
 prepare_workdir
 
-cd ${ORIG}
+cd "${ORIG}"
 
 while true; do
 
@@ -91,7 +90,7 @@ while true; do
         export AWS_REGION=${dynamodb_region}
         export dynamodb_table=${dynamodb_table}
         sandbox-list --to-cleanup --no-headers
-    ) | rush --immediate-output -j ${threads} './wipe_sandbox.sh {1}'
+    ) | rush --immediate-output -j "${threads}" './wipe_sandbox.sh {1}'
 
-    sleep ${poll_interval}
+    sleep "${poll_interval}"
 done

--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -25,6 +25,9 @@ aws_nuke_binary_path="${aws_nuke_binary_path:-/usr/bin/aws-nuke}"
 # Noop: don't actually touch the sandboxes
 noop=${noop:-false}
 
+# python virtualenv
+VENV=${VENV:-~/pool_management/python_virtualenv}
+
 ##############
 
 export threads
@@ -34,11 +37,10 @@ export dynamodb_region
 export poll_interval
 export aws_nuke_binary_path
 export noop
+export VENV
 
 ORIG="$(cd "$(dirname "$0")" || exit; pwd)"
 
-VENV=~/pool_management/python_virtualenv
-export VENV
 
 prepare_workdir() {
     mkdir -p ~/pool_management

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -7,22 +7,6 @@ MAX_ATTEMPTS=2
 # retry after 48h
 TTL_EVENTLOG=$((3600*24))
 
-VENV=~/pool_management/python_virtualenv
-export VENV
-
-prepare_workdir() {
-    mkdir -p ~/pool_management
-
-    if [ ! -d $VENV ]; then
-        echo "Create python virtualenv"
-        python3 -mvenv $VENV
-        . $VENV/bin/activate
-        pip install --upgrade pip
-        pip install -r ${ORIG}/../playbooks/requirements.txt
-    fi
-    . $VENV/bin/activate
-}
-
 sandbox_disable() {
     local sandbox=$1
     read -r -d '' data << EOM
@@ -32,7 +16,7 @@ sandbox_disable() {
 EOM
 
     $VENV/bin/aws --profile "${aws_profile}" \
-        --region us-east-1 \
+        --region "${dynamodb_region}" \
         dynamodb update-item \
         --table-name "${dynamodb_table}" \
         --key "{\"name\": {\"S\": \"${sandbox}\"}}" \
@@ -99,8 +83,6 @@ if [ -z "${sandbox}" ]; then
     echo "sandbox not provided"
     exit 2
 fi
-
-prepare_workdir
 
 sandbox_disable "${sandbox}"
 

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -11,9 +11,9 @@ TTL_EVENTLOG=$((3600*24))
 # Mandatory ENV variables
 : "${dynamodb_table:?"dynamodb_table is unset or null"}"
 : "${dynamodb_region:?"dynamodb_region is unset or null"}"
-: "${sandbox:?"sandbox is unset or empty"}"
 : "${noop:?"noop is unset or empty"}"
 : "${aws_profile:?"aws_profile is unset or empty"}"
+: "${aws_nuke_binary_path:?"aws_nuke_binary_path is unset or empty"}"
 
 checks() {
     if [ -z "${sandbox}" ]; then

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -7,6 +7,20 @@ MAX_ATTEMPTS=2
 # retry after 48h
 TTL_EVENTLOG=$((3600*24))
 
+checks() {
+    if [ -z "${sandbox}" ]; then
+        echo "sandbox not provided"
+        sync
+        exit 2
+    fi
+
+    if [ -z "${VENV}" ]; then
+        echo "VENV is not defined"
+        sync
+        exit 2
+    fi
+}
+
 sandbox_disable() {
     local sandbox=$1
     read -r -d '' data << EOM
@@ -80,11 +94,8 @@ sandbox_reset() {
 }
 
 sandbox=$1
-if [ -z "${sandbox}" ]; then
-    echo "sandbox not provided"
-    sync
-    exit 2
-fi
+
+checks
 
 sandbox_disable "${sandbox}"
 

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -74,6 +74,7 @@ sandbox_reset() {
         rm $eventlog
     else
         echo "$(date) ${sandbox} reset FAILED. See ${logfile}" >&2
+        sync
         exit 3
     fi
 }
@@ -81,6 +82,7 @@ sandbox_reset() {
 sandbox=$1
 if [ -z "${sandbox}" ]; then
     echo "sandbox not provided"
+    sync
     exit 2
 fi
 

--- a/internal/dynamodb/accounts.go
+++ b/internal/dynamodb/accounts.go
@@ -85,7 +85,7 @@ func GetAccounts(filters []expression.ConditionBuilder) ([]account.Account, erro
 	input := &dynamodb.ScanInput{
 		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),
-		TableName:                 aws.String("accounts"),
+		TableName:                 aws.String(os.Getenv("dynamodb_table")),
 		ProjectionExpression:      expr.Projection(),
 		FilterExpression:          expr.Filter(),
 	}

--- a/playbooks/roles/infra-aws-sandbox/defaults/main.yml
+++ b/playbooks/roles/infra-aws-sandbox/defaults/main.yml
@@ -35,7 +35,10 @@ ocpkey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8c3m39CoyA3bbgQUui3MGlJOryfg98NwI
 # variable for RESET operation
 ####################################
 nuke_sandbox: true
-aws_nuke_binary_url: https://github.com/rebuy-de/aws-nuke/releases/download/v2.11.0/aws-nuke-v2.11.0-linux-amd64
+
+aws_nuke_version: v2.19.0
+
+aws_nuke_binary_path: /usr/bin/aws-nuke
 
 aws_nuke_account_blacklist:
   - 017310218799 # Master account

--- a/playbooks/roles/infra-aws-sandbox/defaults/main.yml
+++ b/playbooks/roles/infra-aws-sandbox/defaults/main.yml
@@ -36,8 +36,6 @@ ocpkey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8c3m39CoyA3bbgQUui3MGlJOryfg98NwI
 ####################################
 nuke_sandbox: true
 
-aws_nuke_version: v2.19.0
-
 aws_nuke_binary_path: /usr/bin/aws-nuke
 
 aws_nuke_account_blacklist:

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -1,14 +1,4 @@
 ---
-- name: Download aws-nuke
-  become: true
-  get_url:
-    url: "{{ aws_nuke_binary_url }}"
-    dest: /usr/bin/aws-nuke
-    mode: 755
-    owner: root
-    group: root
-  failed_when: false
-
 - name: Grab or create the public zone
   environment:
     AWS_ACCESS_KEY_ID: "{{ assumed_role.sts_creds.access_key }}"
@@ -44,7 +34,7 @@
 
     - name: Run aws-nuke on sandbox account
       command: >-
-        aws-nuke --profile {{ account_name }}
+        {{ aws_nuke_binary_path }} --profile {{ account_name }}
         -c "{{ output_dir }}/{{ account_name }}_nuke-config.yml"
         --no-dry-run
         --force

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -66,7 +66,7 @@
         - name: Run aws-nuke again
           when: run_aws_nuke_again | default(false)
           command: >-
-            aws-nuke --profile {{ account_name }}
+            {{ aws_nuke_binary_path }} --profile {{ account_name }}
             -c "{{ output_dir }}/{{ account_name }}_nuke-config.yml"
             --no-dry-run
             --force


### PR DESCRIPTION
see GPTEINFRA-4336

This change, if applied, adds the following features:
- test the bash script in noop mode
- use another dynamodb database: different account, region and table
- don't automatically download aws-nuke. Make it a requirement
- update sandbox-list to support different dynamodb table name with `dynamodb_table` env variable
- add build info to the sandbox-list binary
- introduce environment variables to change behavior of the daemon