### PR TITLE
Allow concurrency: lock sandbox when cleaning up

### DIFF
--- a/cmd/sandbox-list/main.go
+++ b/cmd/sandbox-list/main.go
@@ -3,15 +3,16 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
-	"github.com/redhat-gpe/aws-sandbox/internal/account"
-	"github.com/redhat-gpe/aws-sandbox/internal/log"
-	sandboxdb "github.com/redhat-gpe/aws-sandbox/internal/dynamodb"
 	"os"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
+	"github.com/redhat-gpe/aws-sandbox/internal/account"
+	sandboxdb "github.com/redhat-gpe/aws-sandbox/internal/dynamodb"
+	"github.com/redhat-gpe/aws-sandbox/internal/log"
 )
 
 var csvFlag bool
@@ -55,7 +56,11 @@ func (a accountPrint) String() string {
 	/* Do not write true | false to not break current scripts that filter
            using true|false on the whole line */
 	if a.ToCleanup {
-		toCleanupString = "TO_CLEANUP"
+		if a.ConanStatus == "cleanup in progress" {
+			toCleanupString = fmt.Sprintf("IN_PROGRESS (%s)", a.ConanHostname)
+		} else {
+			toCleanupString = "TO_CLEANUP"
+		}
 	} else {
 		toCleanupString = "no"
 	}

--- a/conan/conan-dev.rc
+++ b/conan/conan-dev.rc
@@ -3,4 +3,5 @@ export aws_profile=pool-manager-dev
 export dynamodb_table=accounts-dev
 export dynamodb_region=us-east-1
 export aws_nuke_binary_path=/bin/true
+export poll_interval=1
 export noop=true

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -60,7 +60,7 @@ EOM
             rm "${errlog}"
             return 1
         else
-            echo "$(date -uIs) Cannot mark the sandbox as not available"
+            echo "$(date -uIs) Cannot lock the sandbox" >&2
             cat "${errlog}" >&2
             rm "${errlog}"
             exit 1

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -34,7 +34,7 @@ sandbox_disable() {
     local sandbox=$1
     read -r -d '' data << EOM
   {
-        ":av":      {"BOOL": false},
+        ":av": {"BOOL": false},
         ":st": {"S": "cleanup in progress"},
         ":timestamp": {"S": "$(date -uIs)"},
         ":old": {"S": "$(date -uIs -d "now - ${lock_timeout} hour")"},

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -30,7 +30,7 @@ checks() {
     fi
 }
 
-sandbox_disable() {
+sandbox_lock() {
     local sandbox=$1
     read -r -d '' data << EOM
   {
@@ -129,6 +129,6 @@ sandbox=$1
 
 checks
 
-if sandbox_disable "${sandbox}"; then
+if sandbox_lock "${sandbox}"; then
     sandbox_reset "${sandbox}"
 fi

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -14,6 +14,7 @@ TTL_EVENTLOG=$((3600*24))
 : "${noop:?"noop is unset or empty"}"
 : "${aws_profile:?"aws_profile is unset or empty"}"
 : "${aws_nuke_binary_path:?"aws_nuke_binary_path is unset or empty"}"
+: "${lock_timeout:?"lock_timeout is unset or empty"}"
 
 checks() {
     if [ -z "${sandbox}" ]; then
@@ -33,17 +34,40 @@ sandbox_disable() {
     local sandbox=$1
     read -r -d '' data << EOM
   {
-        ":av":      {"BOOL": false}
+        ":av":      {"BOOL": false},
+        ":st": {"S": "cleanup in progress"},
+        ":timestamp": {"S": "$(date -uIs)"},
+        ":old": {"S": "$(date -uIs -d "now - ${lock_timeout} hour")"},
+        ":host": {"S": "$(hostname)"}
   }
 EOM
 
-    "$VENV/bin/aws" --profile "${aws_profile}" \
+    errlog=$(mktemp)
+
+    if ! "$VENV/bin/aws" --profile "${aws_profile}" \
         --region "${dynamodb_region}" \
         dynamodb update-item \
         --table-name "${dynamodb_table}" \
         --key "{\"name\": {\"S\": \"${sandbox}\"}}" \
-        --update-expression "SET available = :av" \
-        --expression-attribute-values "${data}"
+        --update-expression "SET available = :av, conan_status = :st, conan_timestamp = :timestamp, conan_hostname = :host" \
+        --condition-expression "conan_status <> :st OR conan_timestamp < :old" \
+        --expression-attribute-values "${data}" \
+        2> "${errlog}"
+    then
+
+        if grep -q ConditionalCheckFailedException "${errlog}"; then
+            echo "$(date -uIs) Another process is already cleaning up ${sandbox}: skipping"
+            rm "${errlog}"
+            return 1
+        else
+            echo "$(date -uIs) Cannot mark the sandbox as not available"
+            cat "${errlog}" >&2
+            rm "${errlog}"
+            exit 1
+        fi
+    fi
+
+    return 0
 }
 
 sandbox_reset() {
@@ -64,21 +88,21 @@ sandbox_reset() {
         # and if it failed more than MAX_ATTEMPTS times, skip.
         if [ $age_eventlog -le $TTL_EVENTLOG ] && \
             [ "$(wc -l "${eventlog}" | awk '{print $1}')" -ge ${MAX_ATTEMPTS} ]; then
-            echo "$(date) ${sandbox} Too many attemps, skipping"
+            echo "$(date -uIs) ${sandbox} Too many attemps, skipping"
             return
         fi
     fi
 
 
-    echo "$(date) reset sandbox${s}" >> ~/pool_management/reset.log
-    echo "$(date) reset sandbox${s}" >> "${eventlog}"
+    echo "$(date -uIs) reset sandbox${s}" >> ~/pool_management/reset.log
+    echo "$(date -uIs) reset sandbox${s}" >> "${eventlog}"
 
-    echo "$(date) ${sandbox} reset starting..."
+    echo "$(date -uIs) ${sandbox} reset starting..."
 
     export ANSIBLE_NO_TARGET_SYSLOG=True
 
     if [ "${noop}" != "false" ]; then
-        echo "$(date) ${sandbox} reset OK (noop)"
+        echo "$(date -uIs) ${sandbox} reset OK (noop)"
         rm "${eventlog}"
         return
     fi
@@ -92,10 +116,10 @@ sandbox_reset() {
                      reset_single.yml > "${logfile}"
 
     if [ $? = 0 ]; then
-        echo "$(date) ${sandbox} reset OK"
+        echo "$(date -uIs) ${sandbox} reset OK"
         rm "${eventlog}"
     else
-        echo "$(date) ${sandbox} reset FAILED. See ${logfile}" >&2
+        echo "$(date -uIs) ${sandbox} reset FAILED. See ${logfile}" >&2
         sync
         exit 3
     fi
@@ -105,6 +129,6 @@ sandbox=$1
 
 checks
 
-sandbox_disable "${sandbox}"
-
-sandbox_reset "${sandbox}"
+if sandbox_disable "${sandbox}"; then
+    sandbox_reset "${sandbox}"
+fi

--- a/internal/account/type.go
+++ b/internal/account/type.go
@@ -3,7 +3,6 @@ package account
 type Account struct {
 	Name               string  `json:"name"`
 	Available          bool    `json:"available"`
-	ToCleanup          bool    `json:"to_cleanup"`
 	Guid               string  `json:"guid"`
 	Envtype            string  `json:"envtype"`
 	AccountID          string  `json:"account_id"`
@@ -15,4 +14,9 @@ type Account struct {
 	Comment            string  `json:"comment"`
 	AwsAccessKeyID     string  `json:"aws_access_key_id"`
 	AwsSecretAccessKey string  `json:"aws_secret_access_key"`
+	// Conan
+	ToCleanup          bool    `json:"to_cleanup"`
+	ConanStatus        string  `json:"conan_status"`
+	ConanTimestamp     string  `json:"conan_timestamp"`
+	ConanHostname      string  `json:"conan_hostname"`
 }

--- a/internal/dynamodb/accounts.go
+++ b/internal/dynamodb/accounts.go
@@ -66,6 +66,9 @@ func GetAccounts(filters []expression.ConditionBuilder) ([]account.Account, erro
 		expression.Name("aws:rep:updatetime"),
 		expression.Name("aws_access_key_id"),
 		expression.Name("aws_secret_access_key"),
+		expression.Name("conan_status"),
+		expression.Name("conan_timestamp"),
+		expression.Name("conan_hostname"),
 	)
 
 	builder := expression.NewBuilder()


### PR DESCRIPTION
see GPTEINFRA- 4468

This change, if applied, allows multiple instances of conan to run
in parallel.

This is done by locking the sandbox that is being cleaned up.

- Set column conan_status to 'cleanup in progress'
- Set conan_timestamp to now()
- Set conan_hostname to hostname, it can be useful for troublehooting
  to know on what host it's currently running
- A lock timeouts after N hours. Set the default to 2h.

Define new parameter: lock_timeout

Lock timeout:  the number of hours after which a lock on a sandbox expires.
For ex: '2': a conan process will have 2h to cleanup the sandbox before another
process can claim the sandbox for cleanup.
That parameter prevent a sandbox from being locked forever if something goes wrong with
the conan process owning the lock.

Also change all the date format to iso-8601.

Update sandbox-list to display "IN_PROGRESS (hostname)" in the column `toCleanup?`.