### PR TITLE
Validate Sandbox before sending it back into pool

### DIFF
--- a/playbooks/roles/infra-aws-sandbox/tasks/pool.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/pool.yml
@@ -44,6 +44,9 @@
 
 - when: operation == 'RESET'
   block:
+    - name: Validate Sandbox
+      include_tasks: validate.yaml
+
     - name: Reset account information
       vars:
         _data:

--- a/playbooks/roles/infra-aws-sandbox/tasks/pool.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/pool.yml
@@ -44,6 +44,30 @@
 
 - when: operation == 'RESET'
   block:
+    - name: Pre-Reset account information for validation
+      vars:
+        _data:
+          name:
+            S: "{{ account_name }}"
+          available:
+            BOOL: false
+          account_id:
+            S: "{{ account_id }}"
+          aws_access_key_id:
+            S: "{{ account_user_access_key }}"
+          aws_secret_access_key:
+            S: "{{ account_user_secret_access_key_encrypted }}"
+          hosted_zone_id:
+            S: "{{ account_hosted_zone_id }}"
+          zone:
+            S: "{{ account_name }}{{subdomain_base}}"
+      command: >-
+        aws --profile {{ aws_master_profile }}
+        --region {{ dynamodb_region }}
+        dynamodb put-item
+        --table-name {{ dynamodb_table }}
+        --item '{{ _data | to_json }}'
+
     - name: Validate Sandbox
       include_tasks: validate.yaml
 

--- a/playbooks/roles/infra-aws-sandbox/tasks/unvault.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/unvault.yml
@@ -1,0 +1,10 @@
+---
+- name: Decrypt secret key from sandbox entry
+  command: ansible-vault decrypt --vault-password-file {{ vault_file | quote }}
+  args:
+    stdin: "{{ vaulted_text }}"
+  register: r_secret
+
+- name: Save decrypted key
+  set_fact:
+    sandbox_aws_secret_access_key: "{{ r_secret.stdout }}"

--- a/playbooks/roles/infra-aws-sandbox/tasks/validate.yaml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/validate.yaml
@@ -69,7 +69,7 @@
   assert:
     that: ns_entries == ns_entries_route53
 
-- name: Ensure Red Hat GOLD AMI are accessible from withing the sandbox
+- name: Ensure Red Hat GOLD AMI are accessible from within the sandbox
   ec2_ami_info:
     aws_access_key: "{{ sandbox_aws_access_key_id }}"
     aws_secret_key: "{{ sandbox_aws_secret_access_key }}"

--- a/playbooks/roles/infra-aws-sandbox/tasks/validate.yaml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/validate.yaml
@@ -1,0 +1,88 @@
+---
+- debug:
+    msg: "Validating {{ account_name }}"
+
+- name: Get sandbox
+  vars:
+    _data:
+      name:
+        S: "{{ account_name }}"
+  command: >-
+    aws --profile {{ aws_master_profile }} --region {{ dynamodb_region }}
+    dynamodb get-item
+    --table-name {{ dynamodb_table }}
+    --key '{{ _data | to_json }}'
+  register: r_get
+  changed_when: false
+
+- name: Set fact of dynamodb scan
+  set_fact:
+    query1: "{{ r_get.stdout | from_json }}"
+
+- name: Save sandbox variables
+  set_fact:
+    sandbox_name: "{{ query1.Item.name.S }}"
+    sandbox_zone: "{{ query1.Item.zone.S }}"
+    sandbox_hosted_zone_id: "{{ query1.Item.hosted_zone_id.S }}"
+    sandbox_account: "{{ query1.Item.account_id.S }}"
+    sandbox_account_id: "{{ query1.Item.account_id.S }}"
+    sandbox_aws_access_key_id: "{{ query1.Item.aws_access_key_id.S }}"
+
+- vars:
+    vaulted_text: "{{ query1.Item.aws_secret_access_key.S }}"
+  include_tasks: unvault.yml
+
+- name: Validate AWS access
+  amazon.aws.aws_caller_info:
+    aws_access_key: "{{ sandbox_aws_access_key_id }}"
+    aws_secret_key: "{{ sandbox_aws_secret_access_key }}"
+  register: r_caller_info
+
+- name: Grab facts about the zone
+  route53_info:
+    aws_access_key: "{{ sandbox_aws_access_key_id }}"
+    aws_secret_key: "{{ sandbox_aws_secret_access_key }}"
+    query: hosted_zone
+    hosted_zone_method: details
+    hosted_zone_id: "{{ sandbox_hosted_zone_id }}"
+  register: _route53facts
+  retries: 5
+  delay: "{{ 60|random(start=3, step=1) }}"
+  until: _route53facts is succeeded
+
+- name: Validate route53 zone
+  vars:
+    ns_entries: >-
+      {{ lookup('community.general.dig', sandbox_zone, 'qtype=NS')
+      | split(',')
+      | sort
+      | map('regex_replace', '\.$', '')
+      | list
+      }}
+    ns_entries_route53: >-
+      {{ _route53facts.DelegationSet.NameServers
+      | sort
+      | map('regex_replace', '\.$', '')
+      | list
+      }}
+
+  assert:
+    that: ns_entries == ns_entries_route53
+
+- name: Ensure Red Hat GOLD AMI are accessible from withing the sandbox
+  ec2_ami_info:
+    aws_access_key: "{{ sandbox_aws_access_key_id }}"
+    aws_secret_key: "{{ sandbox_aws_secret_access_key }}"
+    region: us-east-1
+    # Red Hat official
+    owner: 309956199498
+    filters:
+      architecture: x86_64
+      name: RHEL-9.0*Access*
+      is-public: false
+  register: r_image
+
+- assert:
+    that:
+      - r_image.images | length > 0
+      - r_image.images[0].platform_details == 'Red Hat BYOL Linux'

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -1,0 +1,35 @@
+#!/usr/bin/env ansible-playbook
+
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  run_once: yes
+  tasks:
+    - assert:
+        msg: Please set account_num_start
+        that: account_num_start is defined
+
+    - assert:
+        msg: Please set account_num_end
+        that: account_num_end is defined
+
+    - include_role:
+        name: infra-aws-sandbox
+        tasks_from: validate
+      loop: >-
+        {{ range( account_num_start|int, account_num_end|int )|list }}
+      loop_control:
+        loop_var: account_num
+      tags: create
+      vars:
+        available_after_create: true
+        aws_master_profile: pool-manager
+        dynamodb_table: accounts
+        pool_region: us-east-1
+        account_name: sandbox{{account_num}}
+        account_email: sandbox{{account_num}}@opentlc.com
+        account_destination_ou: sandboxes
+        output_dir: ~/pool_management/output_dir_sandbox
+        kerberos_user: hostadmin
+        kerberos_keytab: ~/secrets/hostadmin.keytab
+        operation: VALIDATE

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -20,16 +20,11 @@
         {{ range( account_num_start|int, account_num_end|int )|list }}
       loop_control:
         loop_var: account_num
-      tags: create
+      tags: validate
       vars:
-        available_after_create: true
         aws_master_profile: pool-manager
         dynamodb_table: accounts
         pool_region: us-east-1
         account_name: sandbox{{account_num}}
-        account_email: sandbox{{account_num}}@opentlc.com
-        account_destination_ou: sandboxes
         output_dir: ~/pool_management/output_dir_sandbox
-        kerberos_user: hostadmin
-        kerberos_keytab: ~/secrets/hostadmin.keytab
         operation: VALIDATE


### PR DESCRIPTION
See GPTEINFRA-4335

- Validate AWS access
- Validate route53
- Validate access to GOLD AMIs

Create generic playbook to validate a range of sandboxes. Validation happens when cleaning up a sandbox or when calling that playbook.

Validation is not performed on creation as enabling the GOLD image is a separate process for now.