### PR TITLE
sandbox-list: Print UUID

### DIFF
--- a/cmd/sandbox-list/main.go
+++ b/cmd/sandbox-list/main.go
@@ -77,6 +77,7 @@ func (a accountPrint) String() string {
 		a.Zone,
 		a.HostedZoneID,
 		supdatetime,
+		a.ServiceUUID,
 		toCleanupString,
 		a.Comment,
 	}, separator)
@@ -105,6 +106,7 @@ func printHeaders(w *tabwriter.Writer) {
 		"Zone",
 		"HostedZoneId",
 		"UpdateTime",
+		"UUID",
 		"ToCleanup?",
 		"Comment",
 	}

--- a/internal/account/type.go
+++ b/internal/account/type.go
@@ -6,6 +6,7 @@ type Account struct {
 	NameInt			   int
 	Available          bool    `json:"available"`
 	Guid               string  `json:"guid"`
+	ServiceUUID        string  `json:"service_uuid"`
 	Envtype            string  `json:"envtype"`
 	AccountID          string  `json:"account_id"`
 	Owner              string  `json:"owner"`

--- a/internal/dynamodb/accounts.go
+++ b/internal/dynamodb/accounts.go
@@ -74,6 +74,7 @@ func GetAccounts(filters []expression.ConditionBuilder) ([]account.Account, erro
 		expression.Name("available"),
 		expression.Name("to_cleanup"),
 		expression.Name("guid"),
+		expression.Name("service_uuid"),
 		expression.Name("envtype"),
 		expression.Name("owner"),
 		expression.Name("zone"),


### PR DESCRIPTION
This change, if applied, adds a column to the output of `sandbox-list`: UUID.

Use the column after UpdateTime to be conservative in case some scripts depend on the column orders.